### PR TITLE
feat: remove unneeded mutability

### DIFF
--- a/src/main/java/com/alexandriasoftware/swing/JInputValidator.java
+++ b/src/main/java/com/alexandriasoftware/swing/JInputValidator.java
@@ -227,15 +227,6 @@ public abstract class JInputValidator extends InputVerifier {
     }
 
     /**
-     * Set the preferences for a Validation to this JInputValidator's preferences.
-     *
-     * @param validation the validation to set preferences for
-     */
-    protected final void setValidationPreferences(Validation validation) {
-        validation.setPreferences(preferences);
-    }
-
-    /**
      * Trims input and removes the leading {@code <html>} and trailing
      * {@code </html>} markers if present.
      *

--- a/src/main/java/com/alexandriasoftware/swing/PredicateValidator.java
+++ b/src/main/java/com/alexandriasoftware/swing/PredicateValidator.java
@@ -93,11 +93,9 @@ public class PredicateValidator extends JInputValidator {
     public PredicateValidator(JComponent component, Predicate<String> predicate, Validation invalid, Validation valid, boolean onInput, boolean isVerifying, JInputValidatorPreferences preferences) {
         super(component, onInput, isVerifying, preferences);
         this.predicate = predicate;
-        this.invalid = invalid;
-        setValidationPreferences(this.invalid);
+        this.invalid = new Validation(invalid, preferences);
         if (valid != null) {
-            this.valid = valid;
-            setValidationPreferences(this.valid);
+            this.valid = new Validation(valid, preferences);
         } else {
             this.valid = getNoneValidation();
         }

--- a/src/main/java/com/alexandriasoftware/swing/Validation.java
+++ b/src/main/java/com/alexandriasoftware/swing/Validation.java
@@ -102,6 +102,17 @@ public class Validation {
     }
 
     /**
+     * Create a validation from an existing validation with custom preferences.
+     * 
+     * @param validation the existing validation to base the new validation on;
+     *                   must not be null
+     * @param preferences the preferences to use; must not be null
+     */
+    public Validation(Validation validation, JInputValidatorPreferences preferences) {
+        this(validation.getType(), validation.getMessage(), preferences);
+    }
+
+    /**
      * Get the validation type.
      *
      * @return the validation type
@@ -147,16 +158,6 @@ public class Validation {
         return preferences.getFont();
     }
 
-    /**
-     * Set the preferences to use with this Validation.
-     *
-     * @param preferences the preferences to set; must not be null
-     */
-    // package private
-    void setPreferences(JInputValidatorPreferences preferences) {
-        this.preferences = preferences;
-    }
-    
     @Override
     public int hashCode() {
         int hash = 5;

--- a/src/main/java/com/alexandriasoftware/swing/Validation.java
+++ b/src/main/java/com/alexandriasoftware/swing/Validation.java
@@ -29,7 +29,7 @@ public class Validation {
 
     private final Type type;
     private final String message;
-    private JInputValidatorPreferences preferences;
+    private final JInputValidatorPreferences preferences;
 
     /**
      * The Validation state. The states {@link Type#DANGER} and

--- a/src/main/java/com/alexandriasoftware/swing/Validation.java
+++ b/src/main/java/com/alexandriasoftware/swing/Validation.java
@@ -167,8 +167,8 @@ public class Validation {
     }
 
     /**
-     * @inheritDoc
-     * <p>
+     * {@inheritDoc}
+     *
      * <strong>Note</strong> two Validations are considered equal if
      * {@code getType()} and {@code getMessage()} are equal (the display
      * properties {@code getColor()}, {@code getFont()}, and {@code getIcon()}

--- a/src/main/java/com/alexandriasoftware/swing/Validation.java
+++ b/src/main/java/com/alexandriasoftware/swing/Validation.java
@@ -166,6 +166,14 @@ public class Validation {
         return hash;
     }
 
+    /**
+     * @@inheritDoc
+     * <p>
+     * <strong>Note</strong> two Validations are considered equal if
+     * {@code getType()} and {@code getMessage()} are equal (the display
+     * properties {@code getColor()}, {@code getFont()}, and {@code getIcon()}
+     * are not considered for equality).
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/com/alexandriasoftware/swing/Validation.java
+++ b/src/main/java/com/alexandriasoftware/swing/Validation.java
@@ -167,7 +167,7 @@ public class Validation {
     }
 
     /**
-     * @@inheritDoc
+     * @inheritDoc
      * <p>
      * <strong>Note</strong> two Validations are considered equal if
      * {@code getType()} and {@code getMessage()} are equal (the display

--- a/src/main/java/com/alexandriasoftware/swing/VerifyingValidator.java
+++ b/src/main/java/com/alexandriasoftware/swing/VerifyingValidator.java
@@ -91,11 +91,9 @@ public class VerifyingValidator extends JInputValidator {
     public VerifyingValidator(JComponent component, InputVerifier verifier, Validation invalid, Validation valid, boolean onInput, boolean isVerifying, JInputValidatorPreferences preferences) {
         super(component, onInput, isVerifying, preferences);
         this.verifier = verifier;
-        this.invalid = invalid;
-        setValidationPreferences(this.invalid);
+        this.invalid = new Validation(invalid, preferences);
         if (valid != null) {
-            this.valid = valid;
-            setValidationPreferences(this.valid);
+            this.valid = new Validation(valid, preferences);
         } else {
             this.valid = getNoneValidation();
         }

--- a/src/test/java/com/alexandriasoftware/swing/PredicateValidatorTest.java
+++ b/src/test/java/com/alexandriasoftware/swing/PredicateValidatorTest.java
@@ -76,4 +76,19 @@ class PredicateValidatorTest {
         assertEquals(new Color(0x73BCF7), v1.getColor());
     }
 
+    @Test
+    void testValidValidationsInConstructor() {
+        JTextField c = new JTextField();
+        Validation valid = new Validation(Type.SUCCESS, "");
+        Validation invalid = new Validation(Type.DANGER, "");
+        PredicateValidator v = new PredicateValidator(c, (String t) -> t.equals("test1"), invalid);
+        assertFalse(v.verify(c));
+        assertEquals(invalid, v.getValidation());
+        c.setText("test1");
+        assertTrue(v.verify(c));
+        assertEquals(v.getNoneValidation(), v.getValidation());
+        v = new PredicateValidator(c, (String t) -> t.equals("test1"), invalid, valid, true, true, JInputValidatorPreferences.getPreferences());
+        assertTrue(v.verify(c));
+        assertEquals(valid, v.getValidation());
+    }
 }


### PR DESCRIPTION
This was flagged by spotbugs as [EI_EXPOSE_REP](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#ei-may-expose-internal-representation-by-returning-reference-to-mutable-object-ei-expose-rep) and [EI_EXPOSE_REP2](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#ei2-may-expose-internal-representation-by-incorporating-reference-to-mutable-object-ei-expose-rep2), but since the fix means that setting the preferences on a Validation by copying it (and then using the copy) is now easier than it used to be for dependent code, the fix for these is being treated as a feature enhancement, not as a bug fix (the original code was package private or protected, so it was mostly internal).

If you have subclassed `JInputVerifier` and are setting the preferences on a Validation in your subclass, replace code like `this.setValidationPreferences(this.myValidation);` with `this.myValidation = new Validation(this.myValidation, this.getPreferences());`