### PR TITLE
chore: give up on sonarcloud maven-based analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         - java: 11
           maven: verify
         - java: 17
-          maven: verify site sonar:sonar
+          maven: verify site
         - java: 18
           maven: verify
     steps:
@@ -31,12 +31,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
         uses: actions/cache@v1
         with:
@@ -44,7 +38,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: xvfb-run mvn -B ${{ matrix.maven }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
         run: xvfb-run mvn -B ${{ matrix.maven }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        if: matrix.java == '17'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An [InputVerifier](https://docs.oracle.com/javase/8/docs/api/index.html?javax/sw
 [![CodeQL](https://github.com/rhwood/jinputvalidator/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/rhwood/jinputvalidator/actions/workflows/codeql-analysis.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rhwood_jinputvalidator&metric=alert_status)](https://sonarcloud.io/dashboard?id=rhwood_jinputvalidator)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=rhwood_jinputvalidator&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=rhwood_jinputvalidator)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rhwood_jinputvalidator&metric=coverage)](https://sonarcloud.io/dashboard?id=rhwood_jinputvalidator)
+[![codecov](https://codecov.io/gh/rhwood/jinputvalidator/branch/main/graph/badge.svg?token=pKCkI8SxSg)](https://codecov.io/gh/rhwood/jinputvalidator)
 
 JInputValidator extends the verify idiom to use six states, each with its own graphical representation and tool tip text:
 

--- a/pom.xml
+++ b/pom.xml
@@ -284,9 +284,6 @@ limitations under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sonar.projectKey>rhwood_jinputvalidator</sonar.projectKey>
-        <sonar.organization>rhwood</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
The maven-based Sonarcloud analysis is just unreliable, so switching to automatic (static only) analysis from Sonarcloud. This does mean that a new coverage service will be needed.